### PR TITLE
Add support for LocalSecondaryIndex

### DIFF
--- a/aws-dynamo-derive/Cargo.toml
+++ b/aws-dynamo-derive/Cargo.toml
@@ -22,8 +22,8 @@ syn = { workspace = true, features = ["extra-traits"] }
 [dev-dependencies]
 aws-config = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
 test-context = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/aws-dynamo-derive/src/container.rs
+++ b/aws-dynamo-derive/src/container.rs
@@ -17,6 +17,8 @@ pub struct Container<'a> {
     pub key_schemas: Vec<KeySchemaType>,
     /// ScalarAttributeTypes parsed from attribute
     pub attribute_definitions: Vec<ScalarAttributeType>,
+    /// lsi index (index_name, KeySchemaType)
+    pub local_secondary_index_key_schemas: BTreeMap<String, Vec<KeySchemaType>>,
     /// gsi index (index_name, KeySchemaType)
     pub global_secondary_index_key_schemas: BTreeMap<String, Vec<KeySchemaType>>,
     /// placeholder for conversions
@@ -34,6 +36,7 @@ impl<'a> Container<'a> {
             ty,
             key_schemas: vec![],
             attribute_definitions: vec![],
+            local_secondary_index_key_schemas: BTreeMap::new(),
             global_secondary_index_key_schemas: BTreeMap::new(),
             to_attribute_target_ident,
             to_attribute_token_stream: TokenStream::new(),

--- a/aws-dynamo-derive/src/item.rs
+++ b/aws-dynamo-derive/src/item.rs
@@ -37,11 +37,11 @@ fn get_attribute_types_containers<'a>(
     let mut containers = vec![];
 
     for field in &ds.fields {
-        let ty = &field.ty;
         let ident = field
             .ident
             .as_ref()
             .ok_or(Error::new(field.ident.span(), "field ident not found"))?;
+        let ty = &field.ty;
 
         let container = Container::new(ident, ty, to_attribute_ident);
         let (container, _) = expand_attribute_value(ident, from_attribute_ident, ty, 0, container)?;

--- a/aws-dynamo-derive/src/lib.rs
+++ b/aws-dynamo-derive/src/lib.rs
@@ -63,11 +63,10 @@ use syn::{parse_macro_input, DeriveInput};
 /// async fn create_lsi() {
 ///     // returns HashMap
 ///     let lsi_key_schemas = FooTable::get_local_secondary_index_key_schemas();
-///     let lsi_builder = GlobalSecondaryIndex::builder()
+///     let lsi_builder = LocalSecondaryIndex::builder()
 ///         .index_name(idx_name)
 ///         // defined with attribute
 ///         .set_key_schema(Some(lsi_key_schemas.get("foo_index_1").unwrap().clone()))
-///         .provisioned_throughput(provisioned_throughput.clone())
 ///         .projection(Projection::builder()
 ///             .projection_type(ProjectionType::All)
 ///             .build(),

--- a/aws-dynamo-derive/src/lib.rs
+++ b/aws-dynamo-derive/src/lib.rs
@@ -45,14 +45,37 @@ use syn::{parse_macro_input, DeriveInput};
 /// async fn create_table() {
 ///     // accepts CreateTableFluentBuilder
 ///     let create_table_builder = FooTable::create_table(client.create_table())
+///         .local_secondary_indexes(lsi_builder)
 ///         .global_secondary_indexes(gsi_builder)
 ///         .provisioned_throughput(provisioned_throughput)
 ///         .send()
 ///         .await?;
 /// }
 ///```
+/// In order to set LocalSecondaryIndex, annotate the field with `#[aws_dynamo(local_secondary_index(index_name = "foo_index_1", hash_key))]`.
+/// LSI can be retrieved using method `get_local_secondary_index_key_schemas` automatically derived by macro.
+/// It is imperative that you set the local secondary index along with the CreateTableFluentBuilder if you have LSIs. (https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LCICli.html#LCICli.CreateTableWithIndex)
 /// In order to set GlobalSecondaryIndex, annotate the field with `#[aws_dynamo(global_secondary_index(index_name = "foo_index_1", hash_key))]`.
 /// GSI can be retrieved using method `get_global_secondary_index_key_schemas` automatically derived by macro.
+///
+/// #### LSI Example
+/// ```rust,ignore
+/// async fn create_lsi() {
+///     // returns HashMap
+///     let lsi_key_schemas = FooTable::get_local_secondary_index_key_schemas();
+///     let lsi_builder = GlobalSecondaryIndex::builder()
+///         .index_name(idx_name)
+///         // defined with attribute
+///         .set_key_schema(Some(lsi_key_schemas.get("foo_index_1").unwrap().clone()))
+///         .provisioned_throughput(provisioned_throughput.clone())
+///         .projection(Projection::builder()
+///             .projection_type(ProjectionType::All)
+///             .build(),
+///         )
+///         .build()
+///         .unwrap();
+/// }
+/// ```
 ///
 /// #### GSI Example
 /// ```rust,ignore

--- a/aws-dynamo-derive/src/table.rs
+++ b/aws-dynamo-derive/src/table.rs
@@ -106,11 +106,11 @@ fn get_attribute_types_containers<'a>(
     let mut containers = vec![];
 
     for field in &ds.fields {
-        let ty = &field.ty;
         let ident = field
             .ident
             .as_ref()
             .ok_or(Error::new(field.ident.span(), "field ident not found"))?;
+        let ty = &field.ty;
         let container = Container::new(ident, ty, to_attribute_ident);
         let (mut container, attribute_value_type) =
             expand_attribute_value(ident, from_attribute_ident, ty, 0, container)?;

--- a/aws-dynamo-derive/src/table/parser.rs
+++ b/aws-dynamo-derive/src/table/parser.rs
@@ -43,9 +43,9 @@ pub fn parse_from_dynamo_attrs(
                     field,
                     &table_meta,
                     attribute_value_type,
-                    &mut container.attribute_definitions,
                     &mut container.global_secondary_index_key_schemas,
                 )?;
+
                 Ok(())
             })?;
         }
@@ -124,9 +124,10 @@ fn parse_global_secondary_index_key_schemas(
     field: &Field,
     table: &ParseNestedMeta,
     attribute_value_type: AttributeValueType,
-    attribute_definitions: &mut Vec<ScalarAttributeType>,
     global_secondary_indexes: &mut BTreeMap<String, Vec<KeySchemaType>>,
 ) -> Result<()> {
+    let mut dummy_attribute_definitions: Vec<ScalarAttributeType> = Vec::new();
+
     if table.path.is_ident(GLOBAL_SECONDARY_INDEX_ENTRY) {
         let mut index_name = String::from("");
         table.parse_nested_meta(|nested_meta| {
@@ -143,7 +144,7 @@ fn parse_global_secondary_index_key_schemas(
                     &nested_meta,
                     attribute_value_type,
                     &mut key_schemas,
-                    attribute_definitions,
+                    &mut dummy_attribute_definitions,
                 )?;
             }
 

--- a/aws-dynamo-derive/src/table/parser.rs
+++ b/aws-dynamo-derive/src/table/parser.rs
@@ -1,3 +1,4 @@
+use crate::container::Container;
 use crate::dynamo::attribute_definition::ScalarAttributeType;
 use crate::dynamo::attribute_value::AttributeValueType;
 use crate::dynamo::key_schema::KeySchemaType;
@@ -10,33 +11,40 @@ use syn::meta::ParseNestedMeta;
 use syn::spanned::Spanned;
 use syn::{Attribute, Field, Result};
 
+const LOCAL_SECONDARY_INDEX_ENTRY: &str = "local_secondary_index";
 const GLOBAL_SECONDARY_INDEX_ENTRY: &str = "global_secondary_index";
 const SECONDARY_INDEX_NAME: &str = "index_name";
 
-pub fn parse_from_attrs(
+pub fn parse_from_dynamo_attrs(
     attrs: &[Attribute],
     field: &Field,
     attribute_value_type: AttributeValueType,
-    key_schemas: &mut Vec<KeySchemaType>,
-    attribute_definitions: &mut Vec<ScalarAttributeType>,
-    global_secondary_indexes: &mut BTreeMap<String, Vec<KeySchemaType>>,
+    container: &mut Container,
 ) -> Result<()> {
     for attr in attrs {
         if attr.path().is_ident(AWS_DYNAMO_ATTR_META_ENTRY) {
             attr.parse_nested_meta(|table_meta| {
                 parse_key_schemas(
+                    &[KeySchemaType::HashKey, KeySchemaType::RangeKey],
                     field,
                     &table_meta,
                     attribute_value_type,
-                    key_schemas,
-                    attribute_definitions,
+                    &mut container.key_schemas,
+                    &mut container.attribute_definitions,
+                )?;
+                parse_local_secondary_index_key_schemas(
+                    field,
+                    &table_meta,
+                    attribute_value_type,
+                    &mut container.attribute_definitions,
+                    &mut container.local_secondary_index_key_schemas,
                 )?;
                 parse_global_secondary_index_key_schemas(
                     field,
                     &table_meta,
                     attribute_value_type,
-                    attribute_definitions,
-                    global_secondary_indexes,
+                    &mut container.attribute_definitions,
+                    &mut container.global_secondary_index_key_schemas,
                 )?;
                 Ok(())
             })?;
@@ -47,25 +55,68 @@ pub fn parse_from_attrs(
 }
 
 fn parse_key_schemas(
+    key_types: &[KeySchemaType],
     field: &Field,
     table: &ParseNestedMeta,
     attribute_value_type: AttributeValueType,
     key_schemas: &mut Vec<KeySchemaType>,
     attribute_definitions: &mut Vec<ScalarAttributeType>,
 ) -> Result<()> {
-    for key_type in [KeySchemaType::HashKey, KeySchemaType::RangeKey] {
+    for key_type in key_types {
         if table.path.is_ident(&key_type.to_string()) {
             let scalar_attribute_type = ScalarAttributeType::from_attribute_value_type(
                 attribute_value_type,
                 field.ty.span(),
             )?;
 
-            key_schemas.push(key_type);
+            key_schemas.push(*key_type);
             if !attribute_definitions.contains(&scalar_attribute_type) {
                 attribute_definitions.push(scalar_attribute_type);
             }
         }
     }
+    Ok(())
+}
+
+fn parse_local_secondary_index_key_schemas(
+    field: &Field,
+    table: &ParseNestedMeta,
+    attribute_value_type: AttributeValueType,
+    attribute_definitions: &mut Vec<ScalarAttributeType>,
+    local_secondary_indexes: &mut BTreeMap<String, Vec<KeySchemaType>>,
+) -> Result<()> {
+    if table.path.is_ident(LOCAL_SECONDARY_INDEX_ENTRY) {
+        let mut index_name = String::from("");
+        table.parse_nested_meta(|nested_meta| {
+            let mut key_schemas = vec![];
+            if nested_meta.path.is_ident(SECONDARY_INDEX_NAME) {
+                index_name =
+                    strip_quote_mark(&nested_meta.value()?.parse::<Literal>()?.to_string())
+                        .ok_or(nested_meta.error("invalid index name"))?
+                        .to_string();
+            } else {
+                parse_key_schemas(
+                    &[KeySchemaType::HashKey, KeySchemaType::RangeKey],
+                    field,
+                    &nested_meta,
+                    attribute_value_type,
+                    &mut key_schemas,
+                    attribute_definitions,
+                )?;
+            }
+
+            if index_name.is_empty() {
+                return Err(nested_meta.error("empty index name"));
+            };
+
+            local_secondary_indexes
+                .entry(index_name.clone())
+                .or_default()
+                .extend(key_schemas);
+            Ok(())
+        })?;
+    }
+
     Ok(())
 }
 
@@ -81,11 +132,13 @@ fn parse_global_secondary_index_key_schemas(
         table.parse_nested_meta(|nested_meta| {
             let mut key_schemas = vec![];
             if nested_meta.path.is_ident(SECONDARY_INDEX_NAME) {
-                index_name = strip_quote_mark(&nested_meta.value()?.parse::<Literal>()?.to_string())
-                    .ok_or(nested_meta.error("invalid index name"))?
-                    .to_string();
+                index_name =
+                    strip_quote_mark(&nested_meta.value()?.parse::<Literal>()?.to_string())
+                        .ok_or(nested_meta.error("invalid index name"))?
+                        .to_string();
             } else {
                 parse_key_schemas(
+                    &[KeySchemaType::HashKey, KeySchemaType::RangeKey],
                     field,
                     &nested_meta,
                     attribute_value_type,


### PR DESCRIPTION
* LocalSecondaryIndex (LSI)
  * put `#[aws_dynamo(local_secondary_index(index_name = "lsi1", hash_key))]` to a table's `hash_key`
  * put `#[aws_dynamo(local_secondary_index(index_name = "lsi1", range_key))]` to an attribute you want
* Fixed a bug that GSI's key schemas are added as attribute definitions when creating a table

close #9 